### PR TITLE
Update token.php

### DIFF
--- a/webroot/token.php
+++ b/webroot/token.php
@@ -7,7 +7,7 @@ include('./config.php');
 use Twilio\Jwt\AccessToken;
 use Twilio\Jwt\Grants\VideoGrant;
 use Twilio\Jwt\Grants\SyncGrant;
-use Twilio\Jwt\Grants\IPMessagingGrant;
+use Twilio\Jwt\Grants\IpMessagingGrant;
 
 // An identifier for your app - can be anything you'd like
 $appName = 'TwilioStarterDemo';


### PR DESCRIPTION
Jwt is naming its IpMessagingGrant.php file with lower case 'p'. 
If 'IpMessagingGrant' is typed as 'IPMessagingGrant', when installed on live server, this will raise server error.
Therefore this is a quick fix.