### PR TITLE
[DEVED-3896] Update  to use ::create syntax

### DIFF
--- a/webroot/config-check.php
+++ b/webroot/config-check.php
@@ -2,7 +2,7 @@
 include('../vendor/autoload.php');
 
 // Load environment variables from .env, or environment if available
-$dotenv = new Dotenv\Dotenv(__DIR__);
+$dotenv = Dotenv\Dotenv::create(__DIR__);
 $dotenv->load();
 
 header('Content-type:application/json;charset=utf-8');

--- a/webroot/register.php
+++ b/webroot/register.php
@@ -2,7 +2,7 @@
 include('../vendor/autoload.php');
 
 // Load environment variables from .env, or environment if available
-$dotenv = new Dotenv\Dotenv(__DIR__);
+$dotenv = Dotenv\Dotenv::create(__DIR__);
 $dotenv->load();
 
 // Authenticate with Twilio

--- a/webroot/send-notification.php
+++ b/webroot/send-notification.php
@@ -2,7 +2,7 @@
 include('../vendor/autoload.php');
 
 // Load environment variables from .env, or environment if available
-$dotenv = new Dotenv\Dotenv(__DIR__);
+$dotenv = Dotenv\Dotenv::create(__DIR__);
 $dotenv->load();
 
 // Authenticate with Twilio

--- a/webroot/token.php
+++ b/webroot/token.php
@@ -9,7 +9,7 @@ use Twilio\Jwt\Grants\SyncGrant;
 use Twilio\Jwt\Grants\ChatGrant;
 
 // Load environment variables from .env, or environment if available
-$dotenv = new Dotenv\Dotenv(__DIR__);
+$dotenv = Dotenv\Dotenv::create(__DIR__);
 $dotenv->load();
 
 // An identifier for your app - can be anything you'd like


### PR DESCRIPTION
This commit updates the `config-check.php` file to use the `::create` constructor syntax when creating the `$dotenv` variable. This was flagged by a customer in [DEVED-3896](https://issues.corp.twilio.com/browse/DEVED-3896).

Due to [a change in PHPdotenv](https://github.com/vlucas/phpdotenv), this update is important to keep the SDK working: "Consequently, you will need to replace any occurrences of new Dotenv(...) with Dotenv::create(...)"