### PR TITLE
Obscure sensible values on .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .env
-config.php
 composer.phar
 /vendor/
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ cp .env.example .env
 
 Open `.env` in your favorite text editor and configure the following values.
 
+On production, to avoid showing errors, you should set the variable `DISPLAY_ERRORS` to 
+`0`. For development, it can be set to `1` on development. For more information, read 
+[this](https://phpdelusions.net/articles/error_reporting)
+
 ### Configure account information
 
 Every sample in the demo requires some basic credentials from your Twilio account. Configure these first.

--- a/webroot/.env.example
+++ b/webroot/.env.example
@@ -1,3 +1,6 @@
+# Set it to 0 when running on production. See the README for further explanation
+DISPLAY_ERRORS=0
+
 # Required for all uses
 TWILIO_ACCOUNT_SID=ACXXXXXXXXXXXXXXXXX
 TWILIO_API_KEY=SKXXXXXXXXXXXXXXXXX

--- a/webroot/config-check.js
+++ b/webroot/config-check.js
@@ -23,7 +23,7 @@ $(function() {
   };
 
   var configureField = function(fields, response) {
-    var htmlContent = 'Not configured in config.php';
+    var htmlContent = 'Not configured in .env';
     var cssClass = 'unset';
     return function(fieldId) {
       var configKey = strToConfig(fieldId);

--- a/webroot/register.php
+++ b/webroot/register.php
@@ -5,6 +5,9 @@ include('../vendor/autoload.php');
 $dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
 $dotenv->load();
 
+$DISPLAY_ERRORS = $_ENV['DISPLAY_ERRORS'];
+ini_set('display_errors', $DISPLAY_ERRORS);
+
 // Authenticate with Twilio
 $client = new Twilio\Rest\Client($_ENV['TWILIO_API_KEY'], $_ENV['TWILIO_API_SECRET'], $_ENV['TWILIO_ACCOUNT_SID']);
 

--- a/webroot/send-notification.php
+++ b/webroot/send-notification.php
@@ -5,6 +5,9 @@ include('../vendor/autoload.php');
 $dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
 $dotenv->load();
 
+$DISPLAY_ERRORS = $_ENV['DISPLAY_ERRORS'];
+ini_set('display_errors', $DISPLAY_ERRORS);
+
 // Authenticate with Twilio
 $client = new Twilio\Rest\Client($_ENV['TWILIO_API_KEY'], $_ENV['TWILIO_API_SECRET'], $_ENV['TWILIO_ACCOUNT_SID']);
 
@@ -12,7 +15,6 @@ $client = new Twilio\Rest\Client($_ENV['TWILIO_API_KEY'], $_ENV['TWILIO_API_SECR
 $service = $client->notify->v1->services($_ENV['TWILIO_NOTIFICATION_SERVICE_SID']);
 
 $json = json_decode(file_get_contents('php://input'), true);
-
 
 try {
     $notification = $service->notifications->create(

--- a/webroot/token.php
+++ b/webroot/token.php
@@ -12,6 +12,9 @@ use Twilio\Jwt\Grants\ChatGrant;
 $dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
 $dotenv->load();
 
+$DISPLAY_ERRORS = $_ENV['DISPLAY_ERRORS'];
+ini_set('display_errors', $DISPLAY_ERRORS);
+
 $identity = '';
 
 if (isset($_GET['identity'])) {


### PR DESCRIPTION
Avoids exposing sensible variables on production.

Changes in the PR:

- Change DISPLAY_ERRORS to `false`.
- Set `display_errors` to 0 on production
- Update README. Having a .env file is necessary for the make install step to succeed so now is first on the list.